### PR TITLE
Update Minecraft Wiki links to new domain after fork

### DIFF
--- a/Start_Here.py
+++ b/Start_Here.py
@@ -62,7 +62,7 @@ STARTX, STARTY, STARTZ, ENDX, ENDY, ENDZ = INTF.requestBuildArea()  # BUILDAREA
 # Using the start and end coordinates we are generating a world slice
 # It contains all manner of information, including heightmaps and biomes
 # For further information on what information it contains, see
-#     https://minecraft.fandom.com/wiki/Chunk_format
+#     https://minecraft.wiki/w/Chunk_format
 #
 # IMPORTANT: Keep in mind that a wold slice is a 'snapshot' of the world,
 #   and any changes you make later on will not be reflected in the world slice

--- a/gdpc/lookup.py
+++ b/gdpc/lookup.py
@@ -723,7 +723,7 @@ TRANSPARENT = INVISIBLE + FILTERING + UNOBTRUSIVE + OBTRUSIVE
 
 # ========================================================= map colouring
 # block visualization
-# based on https://minecraft.gamepedia.com/Map_item_format#Base_colors
+# based on https://minecraft.wiki/w/Map_item_format#Base_colors
 # liberty was taken to move stained glass panes and various flowers
 # into the appropriate colour category
 

--- a/gdpc/lookup.py
+++ b/gdpc/lookup.py
@@ -16,7 +16,7 @@ import sys
 # to translate a 255 RGB to hex RGB value
 # >>> def f(r, g, b): return "0x"+(hex(r)+hex(g)+hex(b)).replace("0x", "")
 
-# See https://minecraft.fandom.com/wiki/Data_version#List_of_data_versions
+# See https://minecraft.wiki/w/Data_version#List_of_data_versions
 SUPPORTS = 2566  # Supported Minecraft version code
 
 # all major Minecraft version codes

--- a/gdpc/toolbox.py
+++ b/gdpc/toolbox.py
@@ -121,7 +121,7 @@ def writeBook(text, title="Chronicle", author=__author__,
     - `\\r`: When at start of line, align text to right side
 
     NOTE: For supported special characters see
-        https://minecraft.fandom.com/wiki/Language#Font
+        https://minecraft.wiki/w/Language#Font
     IMPORTANT: When using `\\s` text is directly interpreted by Minecraft,
         so all line breaks must be `\\\\n` to function
     """


### PR DESCRIPTION
The Minecraft Wiki maintainers have decided to move away from Fandom. More information can be found here: https://minecraft.wiki/w/Minecraft_Wiki:Moving_from_Fandom. This PR updates all the URLs to the new domain: minecraft.wiki